### PR TITLE
Update task schedule for testing and plotting for shiny

### DIFF
--- a/att_err_mon.py
+++ b/att_err_mon.py
@@ -177,9 +177,9 @@ def att_err_hist(ref_data, recent_data, label=None, min_dwell_time=1000, outdir=
             bin_width = .05
             lim = 7.5
         bins = np.arange(0, lim + bin_width, bin_width)
-        plt.hist(ref_data[f'{ax}_err'], bins=bins, log=True, normed=True, color='b',
+        plt.hist(ref_data[f'{ax}_err'], bins=bins, log=True, density=True, color='b',
                  alpha=.4, label=f'{d0_str} to {d1_str}')
-        plt.hist(recent_data[f'{ax}_err'], bins=bins, log=True, normed=True, color='r',
+        plt.hist(recent_data[f'{ax}_err'], bins=bins, log=True, density=True, color='r',
                  alpha=.4, label=f'{d2_str} to {d3_str}')
         plt.xlabel(f'{ax} err (arcsec)')
         plt.legend(loc='upper right', fontsize=7)

--- a/task_schedule.cfg
+++ b/task_schedule.cfg
@@ -41,7 +41,7 @@ alert       aca@head.cfa.harvard.edu
 <task attitude_error_mon>
       cron       * * * * *
       check_cron * * * * *
-      exec 1: att_err_mon.py --outdir /proj/sot/ska/www/ASPECT/attitude_error_mon --datadir /proj/sot/ska/data/attitude_error_mon
+      exec 1: att_err_mon.py --outdir $ENV{SKA}/www/ASPECT/attitude_error_mon --datadir $ENV{SKA}/data/attitude_error_mon
       <check>
         <error>
           #    File           Expression


### PR DESCRIPTION
Update task schedule for testing and plotting for shiny

This update is just to remove use of the deprecated-became-broken 'normed' in favor of 'density' for matplotlib hist().  Fixes error

```
AttributeError: 'Rectangle' object has no property 'normed'
```

There are no unit tests.

Functional test was just to run att_err_mon, confirm no errors, and review created plots.