### PR TITLE
Line up the one shot (vs angle and vs time) plots a bit more

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+## Description
+
+<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
+Fixes #
+
+## Interface impacts
+<!-- API changes, file format updates, coordination of changes with the community. -->
+
+## Testing
+<!-- If relevant describe any special setup for testing. -->
+
+### Unit tests
+<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
+- [ ] No unit tests
+- [ ] Mac
+- [ ] Linux
+- [ ] Windows
+
+Independent check of unit tests by [REVIEWER NAME]
+- [ ] [PLATFORM]:
+
+### Functional tests
+<!-- Describe and document results of any functional tests, otherwise leave the text below -->
+No functional testing.

--- a/attitude_error_mon/att_err_mon.py
+++ b/attitude_error_mon/att_err_mon.py
@@ -126,7 +126,7 @@ def one_shot_plot(ref_data, recent_data, outdir="."):
     d2_str = recent_data["date"][0][0:8]
     d3_str = recent_data["date"][-1][0:8]
 
-    plt.figure(figsize=(7, 4))
+    plt.figure(figsize=(9, 4))
     plt.plot(
         ref_data["manvr_angle"],
         ref_data["one_shot"],
@@ -145,16 +145,15 @@ def one_shot_plot(ref_data, recent_data, outdir="."):
         label=f"{d2_str} to {d3_str}",
     )
     plt.grid()
-    plt.xlim(-5, 185)
+    plt.xlim(-15, 225)
     plt.ylim(ymin=0)
     plt.ylabel("One Shot (arcsec)")
     plt.xlabel("Manvr Angle (deg)")
     plt.title("One shot size vs. manvr angle", fontsize=12, y=1.05)
     plt.legend(loc="upper left", fontsize=8)
-    plt.tight_layout()
     plt.savefig(outdir / "one_shot_vs_angle.png")
 
-    plt.figure(figsize=(7, 4))
+    plt.figure(figsize=(9, 4))
     plt.plot(
         ref_data["nmm_time"],
         ref_data["one_shot"],
@@ -179,7 +178,6 @@ def one_shot_plot(ref_data, recent_data, outdir="."):
     plt.xlabel("Time in NMM (s)")
     plt.title("One shot size vs. NMM time", fontsize=12, y=1.05)
     plt.legend(loc="upper left", fontsize=8)
-    plt.tight_layout()
     plt.savefig(outdir / "one_shot_vs_nmmtime.png")
 
 


### PR DESCRIPTION
Line up the one shot (vs angle and vs time) plots a bit more.

For these changes I did not rebuild the package and just tested out of the repo:

```
python attitude_error_mon/att_err_mon.py --outdir /proj/sot/ska/www/ASPECT_ICXC/test_review_outputs/attitude_error_mon-pr18/ --datadir ~/git/attitude_error_mon/ --recent-start 2023:139
```

with output to https://icxc.cfa.harvard.edu/aspect/test_review_outputs/attitude_error_mon-pr18/ 

