### PR TITLE
Update for kadi-with-maude-events and use new reference time of 2025:115 for recent data

### DIFF
--- a/attitude_error_mon/task_schedule.cfg
+++ b/attitude_error_mon/task_schedule.cfg
@@ -41,7 +41,7 @@ alert       aca@head.cfa.harvard.edu
 <task attitude_error_mon>
       cron       * * * * *
       check_cron * * * * *
-      exec 1: attitude_error_mon --maude --outdir $ENV{SKA}/www/ASPECT/attitude_error_mon --datadir $ENV{SKA}/data/attitude_error_mon --recent-start 2025:115
+      exec 1: attitude_error_mon --outdir $ENV{SKA}/www/ASPECT/attitude_error_mon --datadir $ENV{SKA}/data/attitude_error_mon --recent-start 2025:115
       <check>
         <error>
           #    File           Expression

--- a/attitude_error_mon/task_schedule.cfg
+++ b/attitude_error_mon/task_schedule.cfg
@@ -41,7 +41,7 @@ alert       aca@head.cfa.harvard.edu
 <task attitude_error_mon>
       cron       * * * * *
       check_cron * * * * *
-      exec 1: attitude_error_mon --outdir $ENV{SKA}/www/ASPECT/attitude_error_mon --datadir $ENV{SKA}/data/attitude_error_mon --recent-start 2023:139
+      exec 1: attitude_error_mon --maude --outdir $ENV{SKA}/www/ASPECT/attitude_error_mon --datadir $ENV{SKA}/data/attitude_error_mon --recent-start 2025:115
       <check>
         <error>
           #    File           Expression


### PR DESCRIPTION
## Description

Update for kadi-with-maude-events and use new reference time for recent data.

This code already had a flag to use maude for data, but didn't properly handle the kadi events from maude in the case where the maude option was not being used.  I also went back and forth about using maude to update the data and plots and settled on just using cxc data to avoid needing to do retries etc to handle the cases where MAUDE times out for whatever reason.

Additionally, we talked about using the 2025:115 date of the latest IRU cal as a new reference time for recent / red data, so this updates the task_schedule to do that as well.  I can put that in a new PR if needed.


<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Fixes issue that for observations since kadi-with-maude-events, since the AOATTER telem for the up-to-date maneuvers was not available, the processing added records with values of 0 to the data file (seen in the attached plot).  It is a separate question about if it should do that in general, but here the fix is if the application isn't used with the "--maude" flag, it now filters the maneuvers to process such that they cover the available AOATTER telemetry from cxc archive.

![image](https://github.com/user-attachments/assets/655a7f67-63ef-438a-8436-a0673c0c424b)

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] No unit tests

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
I removed the bad data in the "flight" data file and had the new code reprocess since day 2025:103 with and without the maude flag.

maude version
https://icxc.cfa.harvard.edu/aspect/test_review_outputs/attitude_error_mon/pr19/test/

cxc telem version 
https://icxc.cfa.harvard.edu/aspect/test_review_outputs/attitude_error_mon/pr19/cxctest/

![image](https://github.com/user-attachments/assets/24db94ac-8f27-444d-9add-837608644a95)
